### PR TITLE
Turn off site customize option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ Source = "https://github.com/rvandezande/hatch-modulefile"
 [project.entry-points.hatch]
 modulefile = "hatch_modulefile.hooks"
 
-[tool.hatch.envs.default]
+[tool.hatch.envs.test]
 dependencies = [
   "coverage[toml]>=6.5",
   "pytest",
@@ -43,17 +43,8 @@ dependencies = [
 system-packages = true
 dev_mode = true
 
-[tool.hatch.envs.default.scripts]
-test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
-cov-report = [
-  "- coverage combine",
-  "coverage report --show-missing",
-]
-cov = [
-  "test-cov",
-  "cov-report",
-]
+[tool.hatch.envs.test.scripts]
+test = "python -m pytest {args:tests}"
 
 [tool.hatch.version]
 path = "hatch_modulefile/__about__.py"

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -12,6 +12,44 @@ def test_modulefile(new_project: Path):
     build_project()
     install_directory = install_project_venv()
 
+    site_customize = install_directory.joinpath("lib", "python3.7", "site-packages", "_sitecustomize.py") # TODO: hard coded for python/3.7
+    assert site_customize.exists()
+
+    modulefile = install_directory.joinpath("lib", "python3.7", "site-packages", "modulefiles", "my-app") # TODO: hard coded for python/3.7
+    assert modulefile.exists()
+
+    text = modulefile.read_text()
+
+    requirements = [s.strip() for s in text.split("necessary       {\n")[1].split("}", 1)[0].splitlines()]
+    assert requirements == ["python/3.7", "my_module"]
+    assert get_setting(text, "setenv") == [["QT_XCB_GL_INTEGRATION", "none"]]
+    assert get_setting(text, "prepend-path") == [["PATH", "$venv/bin"], ["PATH", "/my/custom/path"]]
+    assert get_setting(text, "append-path") == [
+        ["PYTHON_SITE_PACKAGES", "$venv/lib/python3.7/site-packages"],
+        ["PYTHONPATH", "$venv/lib/python3.7/site-packages"],
+        ["OTHER_VARIABLE", "/my/custom/path2"]
+    ]
+
+    assert requirements == ["python/3.7", "my_module"]
+
+
+def get_setting(text: str, key: str) -> list[tuple[str, str]]:
+    environments = []
+    for line in text.splitlines():
+        if line.startswith(key):
+            environments.append(line.split()[1:])
+
+    return environments
+
+
+@pytest.mark.slow
+def test_modulefile_no_site_customize(new_project_no_site_customize: Path):
+    build_project()
+    install_directory = install_project_venv()
+
+    site_customize = install_directory.joinpath("lib", "python3.7", "site-packages", "_sitecustomize.py") # TODO: hard coded for python/3.7
+    assert not site_customize.exists()
+    
     modulefile = install_directory.joinpath("lib", "python3.7", "site-packages", "modulefiles", "my-app") # TODO: hard coded for python/3.7
     assert modulefile.exists()
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -60,7 +60,6 @@ def test_modulefile_no_site_customize(new_project_no_site_customize: Path):
     assert get_setting(text, "setenv") == [["QT_XCB_GL_INTEGRATION", "none"]]
     assert get_setting(text, "prepend-path") == [["PATH", "$venv/bin"], ["PATH", "/my/custom/path"]]
     assert get_setting(text, "append-path") == [
-        ["PYTHON_SITE_PACKAGES", "$venv/lib/python3.7/site-packages"],
         ["PYTHONPATH", "$venv/lib/python3.7/site-packages"],
         ["OTHER_VARIABLE", "/my/custom/path2"]
     ]


### PR DESCRIPTION
Added flag for turning off the automatic creation of site-customize. Useful for installing standalone tools that call other python functions and want to avoid interactions between packages.